### PR TITLE
Check for empty note in dataset_creator.py

### DIFF
--- a/src/robust_deid/ner_datasets/dataset_creator.py
+++ b/src/robust_deid/ner_datasets/dataset_creator.py
@@ -118,6 +118,11 @@ class DatasetCreator(object):
             note = json.loads(line)
             note_text = note[token_text_key]
             note_id = note[metadata_key][note_id_key]
+            
+            # Skip to next note if empty string
+            if not note_text:
+                continue
+            
             if mode == 'train':
                 note_spans = note[span_text_key]
             # No spans in predict mode


### PR DESCRIPTION
If the note in the input file is an empty string, the dataset throws an error. This change checks for an empty.